### PR TITLE
Fix spurious value added after order by in SQL statements

### DIFF
--- a/lib/PGObject.pm
+++ b/lib/PGObject.pm
@@ -312,8 +312,10 @@ sub call_procedure {
     my $order = '';
     if ($args{orderby}){
         $order = join(', ', map {
-                                  $_ =~ s/\s+(ASC|DESC)$//i;
-                                  my $dir = $1;
+                                  my $dir = undef;
+                                  if ( $_ =~ s/\S+(ASC|DESC)$//i ) {
+                                      my $dir = $1;
+                                  }
                                   defined $dir ? $dbh->quote_identifier($_)
                                                   . " $dir"
                                                : $dbh->quote_identifier($_);

--- a/lib/PGObject.pm
+++ b/lib/PGObject.pm
@@ -313,7 +313,7 @@ sub call_procedure {
     if ($args{orderby}){
         $order = join(', ', map {
                                   my $dir = undef;
-                                  if ( $_ =~ s/\S+(ASC|DESC)$//i ) {
+                                  if ( $_ =~ s/\s+(ASC|DESC)$//i ) {
                                       my $dir = $1;
                                   }
                                   defined $dir ? $dbh->quote_identifier($_)

--- a/lib/PGObject.pm
+++ b/lib/PGObject.pm
@@ -313,7 +313,7 @@ sub call_procedure {
     if ($args{orderby}){
         $order = join(', ', map {
                                   my $dir = undef;
-                                  if ( $_ =~ s/\s+(ASC|DESC)$//i ) {
+                                  if ( s/\s+(ASC|DESC)$//i ) {
                                       my $dir = $1;
                                   }
                                   defined $dir ? $dbh->quote_identifier($_)

--- a/lib/PGObject.pm
+++ b/lib/PGObject.pm
@@ -313,8 +313,8 @@ sub call_procedure {
     if ($args{orderby}){
         $order = join(', ', map {
                                   my $dir = undef;
-                                  if ( s/\s+(ASC|DESC)$//i ) {
-                                      my $dir = $1;
+                                  if ( s/\s+(ASC|DESC)//i ) {
+                                      $dir = $1;
                                   }
                                   defined $dir ? $dbh->quote_identifier($_)
                                                   . " $dir"

--- a/lib/PGObject.pm
+++ b/lib/PGObject.pm
@@ -313,7 +313,7 @@ sub call_procedure {
     if ($args{orderby}){
         $order = join(', ', map {
                                   my $dir = undef;
-                                  if ( s/\s+(ASC|DESC)//i ) {
+                                  if ( s/\A\s+(ASC|DESC)\s*\z//i ) {
                                       $dir = $1;
                                   }
                                   defined $dir ? $dbh->quote_identifier($_)


### PR DESCRIPTION
Fix the orderby problem. Original code assumes that $1 is always set by the regex.
It doesn't happen if the regex doesn't match and it uses a value assigned elsewhere.